### PR TITLE
Moved add_option.js to polls/new, wrapped function in .ready

### DIFF
--- a/app/assets/javascripts/add_option.js
+++ b/app/assets/javascripts/add_option.js
@@ -1,5 +1,0 @@
-var $options = $('.options-fields')
-
-$('#add-option').on('click', function(){
-	$("<label>Option</label><input type='text' name='poll[options][]' id='poll_options'></input>").appendTo($options);
-});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,4 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require_tree ./polls
 //= require_tree .

--- a/app/assets/javascripts/polls.coffee
+++ b/app/assets/javascripts/polls.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/polls/new.js
+++ b/app/assets/javascripts/polls/new.js
@@ -1,0 +1,5 @@
+$(document).ready(function(){
+  $('#add-option').on('click', function(){
+    $('.options-fields').append("<label>Option</label><input type='text' name='poll[options][]' id='poll_options'></input>");
+  });
+});


### PR DESCRIPTION
These changes allow me to append the new html inside of the add-options div in a manner that generates html like my earlier gist: https://gist.github.com/jkosz/d42a0568527d439671f5.  I think that if you wanted to use the `add_options.js`, you'd need to include it directly into the .erb file because the asset pipeline won't pick that file up by name and render it based on the controller you're using (polls).  I'm unsure of how necessary the `$(document).ready(...` code is at all, but it's what I found worked when I attempted to fiddle it/google for why the click handler wasn't registering.  If there's someone in Turing with better .js knowledge I'd definitely hit them up about that.  Again, I still have no idea at all if this is the intended design of the code/if this is what you want it to be doing.  If you want to talk about it and/or pair on it, please let me know.
